### PR TITLE
translation of building_php

### DIFF
--- a/Book/build_system.rst
+++ b/Book/build_system.rst
@@ -1,5 +1,5 @@
 PHP yapı sistemini kullanmak
-==========================
+============================
 
 Bu bölümde PHP yapı sistemini kullanarak PHP eklentilerini ve PHP'yi nasıl derleyeceğinizi anlatacağız.
 Henüz autoconf yapılandırma talimatları üzerinde durulmayacak, sadece araçların nasıl kullanılacağı

--- a/Book/build_system/building_php.rst
+++ b/Book/build_system/building_php.rst
@@ -3,7 +3,7 @@
 .. _building_php:
 
 PHP'yi yapılandırmak
-============
+====================
 
 Bu bölüm, PHP'yi, eklenti geliştirme veya çekirdek üzerinde modifikasyonlar yapabilmeye uygun şekilde derlemeyi
 açıklayacaktır.
@@ -19,7 +19,7 @@ dair genel bir bakış açısı sağlar, detaylı açıklamalar bu kitabın kaps
 .. [#] Sorumluluk reddi: PHP'yi Windows'ta derleme esnasında doğabilecek olumsuz etkilerden sorumlu değiliz.
 
 Neden paketleri kullanmıyorsun?
----------------------
+-------------------------------
 
 PHP'yi kullanıyorsanız, büyük ihtimalle paketleri yüklerken ``sudo apt-get install php`` gibi bir komut
 kullandınız. Gerçek derleme işleminden bahsetmeye geçmeden önce, elle derleme yapmanın gerekliliğini ve
@@ -50,7 +50,7 @@ ya da eklenti yazmak için yardım kanallarımızı kullanmak istiyorsanız, dai
 .. _`php.net`: http://www.php.net
 
 Kaynak kodunu edinmek
--------------------------
+---------------------
 
 PHP'yi yapılandırmadan önce, kaynak kodunu edinmeniz gerekmektedir. Kodu edinmenin iki yolu var: Arşiv dosyasını
 `PHP'nin indirme sayfasından`_ ya da git reposundan `git.php.net`_ (ya da
@@ -89,9 +89,7 @@ ilk üçü yüklü olarak gelecektir):
 * ``automake`` (1.4 ya da üzeri), ``Makefile.in`` dosyalarını oluşturur.
 * ``libtool``, paylaşımlı kütüphaneleri yönetmeye yardımcı olur.
 * ``bison`` (2.4 ya da üzeri), PHP ayrıştırıcısını oluşturmak için kullanılır.
-* (opsiyonel) ``re2c``, PHP lekserini/ayrıştırıcısını oluşturmak için kullanılır. Eğer kaynak kodunu git reposundan
-edindiyseniz, içerisinde daha önceden oluşturulmuş bir lekser/ayrıştırıcı bulunmaktadır. Üzerinde değişiklik yapmak
-isterseniz, sadece re2c'e ihtiyacınız olacaktır.
+* (opsiyonel) ``re2c``, PHP lekserini/ayrıştırıcısını oluşturmak için kullanılır. Eğer kaynak kodunu git reposundan edindiyseniz, içerisinde daha önceden oluşturulmuş bir lekser/ayrıştırıcı bulunmaktadır, üzerinde değişiklik yapmak isterseniz,sadece re2c'e ihtiyacınız olacaktır.
 
 Bunların hepsini Debian/Ubuntu üzerinde, aşağıdaki komutu çalıştırarak yükleyebilirsiniz::
 
@@ -111,7 +109,7 @@ tek seferde yükleyebilirsiniz. Sadece varsayılan yapılandırmayı istiyorsan�
 .. _Git SSS: https://wiki.php.net/vcs/gitfaq
 
 Yapılandırma önizlemesi
---------------
+-----------------------
 
 Before taking a closer look at what the individual build steps do, here are the commands you need to execute for a
 "default" PHP build::
@@ -139,7 +137,7 @@ development.
 Now lets take a closer look at the individual build steps!
 
 ``./buildconf`` skripti
---------------------------
+-----------------------
 
 If you are building from the git repository, the first thing you'll have to do is run the ``./buildconf`` script. This
 script does little more than invoking the ``build/build.mk`` makefile, which in turn calls ``build/build2.mk``.
@@ -167,7 +165,7 @@ If you update your git repository using ``git pull`` (or some other command) and
 step, this usually means that something in the build configuration changed and you need to run ``./buildconf --force``.
 
 ``./configure`` skripti
---------------------------
+-----------------------
 
 Once the ``./configure`` script is generated you can make use of it to customize your PHP build. You can list all
 supported options using ``--help``::
@@ -299,7 +297,7 @@ In this configuration the build will make use of clang (instead of gcc) and use 
 (``-O3 -march=native``).
 
 ``make`` ve ``make install``
------------------------------
+----------------------------
 
 After everything is configured, you can use ``make`` to perform the actual compilation::
 
@@ -429,7 +427,7 @@ about your build, e.g. your configure options or the default extension directory
 ``./php -i`` (phpinfo), but ``php-config`` provides it in a simpler form (which can be easily used by automated tools).
 
 Test ortamını çalıştırmak
-----------------------
+-------------------------
 
 If the ``make`` command finishes successfully, it will print a message encouraging you to run ``make test``:
 
@@ -481,7 +479,7 @@ We will take a more detailed look at the ``run-tests.php`` system later, in part
 own tests and how to debug test failures.
 
 Derleme problemlerini gidermek ve ``make clean`` komutu
-----------------------------------------------
+-------------------------------------------------------
 
 As you may know ``make`` performs an incremental build, i.e. it will not recompile all files, but only those ``.c``
 files that changed since the last invocation. This is a great way to shorten build times, but it doesn't always work

--- a/Book/build_system/building_php.rst
+++ b/Book/build_system/building_php.rst
@@ -79,32 +79,31 @@ gerektiğini de açıklıyor. Ek olarak, çoklu klasör mantığıyla, farklı P
 çalışılabileceğinize dair ayarların da açıklaması mevcut. Bu yöntem, yazdığınız eklentileri veya
 yaptığınız değişiklikleri farklı versiyonlar üzerinde, farklı ayarlarla test etmede faydalı olacaktır.
 
-Before continuing you should also install some basic build dependencies with your package manager (you'll likely already
-have the first three installed by default):
+Devam etmeden önce, paket yöneticiniz vasıtasıyla bazı bağlılıkları yüklemeniz gerekmektedir (büyük ihtimalle
+ilk üçü yüklü olarak gelecektir):
 
-Devam etmeden önce, bazı temel yapılandırma bap
+* ``gcc`` veya başka bir derleyici paketi.
+* ``libc-dev``, başlıkları ve C standart kütüphanesini içerir.
+* ``make``, PHP'nin kullandığı kurulum aracı.
+* ``autoconf`` (2.59 ya da üzeri), ``configure`` skriptini oluşturmak için kullanılır.
+* ``automake`` (1.4 ya da üzeri), ``Makefile.in`` dosyalarını oluşturur.
+* ``libtool``, paylaşımlı kütüphaneleri yönetmeye yardımcı olur.
+* ``bison`` (2.4 ya da üzeri), PHP ayrıştırıcısını oluşturmak için kullanılır.
+* (opsiyonel) ``re2c``, PHP lekserini/ayrıştırıcısını oluşturmak için kullanılır. Eğer kaynak kodunu git reposundan
+edindiyseniz, içerisinde daha önceden oluşturulmuş bir lekser/ayrıştırıcı bulunmaktadır. Üzerinde değişiklik yapmak
+isterseniz, sadece re2c'e ihtiyacınız olacaktır.
 
-* ``gcc`` or some other compiler suite.
-* ``libc-dev``, which provides the C standard library, including headers.
-* ``make``, which is the build-management tool PHP uses.
-* ``autoconf`` (2.59 or higher), which is used to generate the ``configure`` script.
-* ``automake`` (1.4 or higher), which generates ``Makefile.in`` files.
-* ``libtool``, which helps manage shared libraries.
-* ``bison`` (2.4 or higher), which is used to generate the PHP parser.
-* (optional) ``re2c``, which is used to generate the PHP lexer. As the git repository already contains a generated
-  lexer you will only need re2c if you wish to make changes to it.
-
-On Debian/Ubuntu you can install all these with the following command::
+Bunların hepsini Debian/Ubuntu üzerinde, aşağıdaki komutu çalıştırarak yükleyebilirsiniz::
 
     ~/php-src> sudo apt-get install build-essential autoconf automake libtool bison re2c
 
-Depending on the extensions that you enable during the ``./configure`` stage PHP will need a number of additional
-libraries. When installing these, check if there is a version of the package ending in ``-dev`` or ``-devel`` and
-install them instead. The packages without ``dev`` typically do not contain necessary header files. For example a
-default PHP build will require libxml, which you can install via the ``libxml2-dev`` package.
+``./configure`` aşamasında etkinleştirdiğiniz eklentilere bağlı olarak, PHP farklı kütüphanelere de ihtiyaç duyabilir.
+Bunları yüklerken, ilgili paketin sonu ``-dev`` ya da ``-devel`` biten versiyonu varsa, onu yükleyin.
+``dev`` etiketi barındırmayan paketler genelde gerekli başlık dosyalarını içermezler. Örneğin varsayılan bir
+PHP yapılandırması libxml'e ihtiyaç duyar, bunu da ``libxml2-dev`` olarak yüklersiniz.
 
-If you are using Debian or Ubuntu you can use ``sudo apt-get build-dep php5`` to install a large number of optional
-build-dependencies in one go. If you are only aiming for a default build, many of them will not be necessary though.
+Eğer Debian ya da Ubuntu kullanıyorsanız, you can use ``sudo apt-get build-dep php5`` komutuyla birçok bağlılığı
+tek seferde yükleyebilirsiniz. Sadece varsayılan yapılandırmayı istiyorsanız, bunların birçoğu gereksiz olacaktır.
 
 .. _PHP'nin indirme sayfasından: http://www.php.net/downloads.php
 .. _git.php.net: http://git.php.net

--- a/Book/build_system/building_php.rst
+++ b/Book/build_system/building_php.rst
@@ -52,30 +52,32 @@ ya da eklenti yazmak için yardım kanallarımızı kullanmak istiyorsanız, dai
 Kaynak kodu edinmek
 -------------------------
 
-Before you can build PHP you first need to obtain its source code. There are two ways to do this: You can either
-download an archive from `PHP's download page`_ or clone the git repository from `git.php.net`_ (or the mirror on
-`Github`_).
+PHP'yi yapılandırmadan önce, kaynak kodunu edinmeniz gerekmektedir. Kodu edinmenin iki yolu var: Arşiv dosyasını
+`PHP'nin indirme sayfasından`_ ya da git reposundan `git.php.net`_ (ya da
+`Github`_ ikiz bağlantısından) edinebilirsiniz.
 
-The build process is slightly different for both cases: The git repository doesn't bundle a ``configure`` script, so
-you'll need to generate it using the ``buildconf`` script, which makes use of autoconf. Furthermore the git repository
-does not contain a pregenerated parser, so you'll also need to have bison installed.
+Yukarıdaki her iki durum için yapılandırma işlemi farklı olarak gerçekleşiyor: Git reposundaki arşiv bir ``configure`` 
+skripti içermiyor. Bundan dolayı, aslında ``autoconf``'u kullanan ``buildconf`` skriptini kullanarak, bir ``configure`` 
+skripti oluşturmanız gerekecek. Ek olarak, git reposu önceden oluşturulmuş bir ayrıştırıcı içermiyor, bu eksikliğin
+giderilmesi için bilgisayarınızda bison'un yüklü olması gerekiyor.
 
-We recommend to checkout out the source code from git, because this will provide you with an easy way to keep your
-installation updated and to try your code with different versions. A git checkout is also required if you want to
-submit patches or pull requests for PHP.
+PHP kaynak kodunu git üzerinden edinmenizi tavsiye ediyoruz, bu yöntem ile kurulumunuz en güncel halde kalacak ve
+kodunuzu farklı PHP versiyonları ile deneyebileceksiniz. Aynı zamanda, PHP yaması veya pull request yapmak 
+istediğinizde yine kodu git üzerinden çekmiş olmanız gerekmektedir.
 
-To clone the repository, run the following commands in your shell::
+Repoyu klonlamak için, aşağıdaki komutları kabuk(shell) üzerinde çalıştırın::
 
     ~> git clone http://git.php.net/repository/php-src.git
     ~> cd php-src
-    # by default you will be on the master branch, which is the current
-    # development version. You can check out a stable branch instead:
+    # ilk olarak master branch'inde olacaksınız, stabil bir versiyona geçmek isterseniz
+    # aşağıdaki komutu kullanabilirsiniz:
     ~/php-src> git checkout PHP-5.5
 
-If you have issues with the git checkout, take a look at the `Git FAQ`_ on the PHP wiki. The Git FAQ also explains how
-to setup git if you want to contribute to PHP itself. Furthermore it contains instructions on setting up multiple
-working directories for different PHP versions. This can be very useful if you need to test your extensions or changes
-against multiple PHP versions and configurations.
+git checkout ile ilgili problem yaşıyorsanız, PHP wiki'sindeki `Git SSS`_'a bakabilirsiniz. Git SSS aynı zamanda,
+PHP için geliştirme yapıp katkıda bulunmak istiyorsanız, buna uygun nasıl bir kurulum yapmanız
+gerektiğini de açıklıyor. Ek olarak, çoklu klasör mantığıyla, farklı PHP versiyonları üzerinde nasıl
+çalışılabileceğinize dair ayarların da açıklaması mevcut. Bu yöntem, yazdığınız eklentileri veya
+yaptığınız değişiklikleri farklı versiyonlar üzerinde, farklı ayarlarla test etmede faydalı olacaktır.
 
 Before continuing you should also install some basic build dependencies with your package manager (you'll likely already
 have the first three installed by default):
@@ -102,10 +104,10 @@ default PHP build will require libxml, which you can install via the ``libxml2-d
 If you are using Debian or Ubuntu you can use ``sudo apt-get build-dep php5`` to install a large number of optional
 build-dependencies in one go. If you are only aiming for a default build, many of them will not be necessary though.
 
-.. _PHP's download page: http://www.php.net/downloads.php
+.. _PHP'nin indirme sayfasından: http://www.php.net/downloads.php
 .. _git.php.net: http://git.php.net
 .. _Github: http://www.github.com/php/php-src
-.. _Git FAQ: https://wiki.php.net/vcs/gitfaq
+.. _Git SSS: https://wiki.php.net/vcs/gitfaq
 
 Yapılandırma önizlemesi
 --------------

--- a/Book/build_system/building_php.rst
+++ b/Book/build_system/building_php.rst
@@ -49,7 +49,7 @@ ya da eklenti yazmak için yardım kanallarımızı kullanmak istiyorsanız, dai
 
 .. _`php.net`: http://www.php.net
 
-Kaynak kodu edinmek
+Kaynak kodunu edinmek
 -------------------------
 
 PHP'yi yapılandırmadan önce, kaynak kodunu edinmeniz gerekmektedir. Kodu edinmenin iki yolu var: Arşiv dosyasını
@@ -81,6 +81,8 @@ yaptığınız değişiklikleri farklı versiyonlar üzerinde, farklı ayarlarla
 
 Before continuing you should also install some basic build dependencies with your package manager (you'll likely already
 have the first three installed by default):
+
+Devam etmeden önce, bazı temel yapılandırma bap
 
 * ``gcc`` or some other compiler suite.
 * ``libc-dev``, which provides the C standard library, including headers.


### PR DESCRIPTION
'Obtaining the source code' section translated into Turkish and sphinx warnings are fixed.